### PR TITLE
Add support for EN1990 reliability classes

### DIFF
--- a/code/calibration/calibration_utils/calibration/obj_fun.m
+++ b/code/calibration/calibration_utils/calibration/obj_fun.m
@@ -35,24 +35,26 @@ parfor ii = 1:n_ds
     flag_form(ii)          = formresults.flag;
 end
 
+% Commmented out because we do not have non-converged analyses and 
+% `run_reli_subsetsim` is not harmonized with the rest of the code.
 % for non-converged FORM analyses, do subset simulation
 % nb: the reason FORM do not converge is because it is jumping between two
 %     points as a result of the v_min check in EC2 shear formula
-if sum(flag_form) < n_ds
-    nonconvFORM = find(~flag_form);
-    n_ds_FORM   = length(nonconvFORM);
-    beta_FORM   = beta(nonconvFORM);
-    print(['Number of non-converged FORM analyses: ', num2str(n_ds_FORM)])
-    for ii = 1:n_ds_FORM
-    %parfor ii = 1:n_ds_FORM
-        ds_num                                  = nonconvFORM(ii);
-        Prob_ii                                 = Prob(ds_num);
-        [beta(ds_num), subsetsimulationresults] = run_reli_subsetsim(Prob_ii, Options);
-        alphas{ds_num}                          = {};
-    end
-    beta_SS     = beta(nonconvFORM);
-%     beta_FORM - beta_SS
-end
+% if sum(flag_form) < n_ds
+%     nonconvFORM = find(~flag_form);
+%     n_ds_FORM   = length(nonconvFORM);
+% %     beta_FORM   = beta(nonconvFORM);
+%     print(['Number of non-converged FORM analyses: ', num2str(n_ds_FORM)])
+%     for ii = 1:n_ds_FORM
+%     %parfor ii = 1:n_ds_FORM
+%         ds_num                                  = nonconvFORM(ii);
+%         Prob_ii                                 = Prob(ds_num);
+%         [beta(ds_num), ~] = run_reli_subsetsim(Prob_ii, Options);
+%         alphas{ds_num}                          = {};
+%     end
+% %     beta_SS     = beta(nonconvFORM);
+% %     beta_FORM - beta_SS
+% end
 
 
 % -------------------------------------------------------------------------

--- a/code/calibration/calibration_utils/management_and_misc/save_results_for_visu.m
+++ b/code/calibration/calibration_utils/management_and_misc/save_results_for_visu.m
@@ -5,7 +5,7 @@
 
 function save_results_for_visu(fname, output)
 
-load(['./results/', fname, '.mat'], 'Options', 'Results', 'DS')
+load(['./results/', fname, '.mat'], 'Results', 'DS')
 
 % create all possible combinations for the design scenarios
 combis          = DS.combis;

--- a/code/calibration/calibration_utils/reliability_analysis/run_reli.m
+++ b/code/calibration/calibration_utils/reliability_analysis/run_reli.m
@@ -83,7 +83,7 @@ marg(n_var+2,:)                 = [0,  load_comb,  0,  load_comb,  NaN,  NaN,  N
 % option for the resistance formula
 marg(n_var+3,:)                 = [0,  consider_VRmin,  0,  consider_VRmin,  NaN,  NaN,  NaN,  NaN, 0];
 
-probdata.name                   = {probdata.name{:}, 'resi_model', 'load_comb', 'consider_VRmin'}'; 
+probdata.name                   = [probdata.name(:)', {'resi_model'}, {'load_comb'}, {'consider_VRmin'}]'; 
 n_var                           = n_var + 3;
 
 probdata.marg                   = marg;

--- a/code/calibration/calibration_utils/reliability_analysis/run_reli_theta_Rk.m
+++ b/code/calibration/calibration_utils/reliability_analysis/run_reli_theta_Rk.m
@@ -113,7 +113,7 @@ marg(n_var+2,:)                 = [0,  resi_model,  0,  resi_model,  NaN,  NaN, 
 % option for the resistance formula
 marg(n_var+3,:)                 = [0,  consider_VRmin,  0,  consider_VRmin,  NaN,  NaN,  NaN,  NaN, 0];
 
-probdata.name                   = {probdata.name{:}, 'V_Rc_repr', 'resi_model', 'consider_VRmin'}; 
+probdata.name                   = [probdata.name(:)', {'V_Rc_repr'}, {'resi_model'}, {'consider_VRmin'}]; 
 n_var                           = n_var + 3;
 
 probdata.marg                   = marg;

--- a/code/calibration/calibration_utils/reliability_analysis/update_Prob.m
+++ b/code/calibration/calibration_utils/reliability_analysis/update_Prob.m
@@ -38,7 +38,7 @@ for ii = 1:n_rv
         X.std = NaN;
     end
     if X.dist == 32
-        load(['tmp\vector_distr_', num2str(X.dist_ID), '.mat'], 'x_grid', 'pdf', 'cdf')
+        load(['tmp\vector_distr_', num2str(X.dist_ID), '.mat'], 'x_grid', 'pdf')
 
         X.mean      = trapz(x_grid, pdf.*x_grid);
         X.std       = sqrt(trapz(x_grid, pdf.*(x_grid-X.mean).^2));

--- a/code/calibration/calibration_utils/standard_related/gen_DS.m
+++ b/code/calibration/calibration_utils/standard_related/gen_DS.m
@@ -21,7 +21,6 @@ function [Prob, DS] = gen_DS(free_par, Prob, Prob_actions, DS, Options)
 %--------------------------------------------------------------------------
 verbose         = Options.verbose;
 
-consider_VRmin  = Options.consider_VRmin;
 load_combs      = Options.load_combs;
 n_lc            = length(load_combs);
 

--- a/code/calibration/calibration_utils/standard_related/gen_DS.m
+++ b/code/calibration/calibration_utils/standard_related/gen_DS.m
@@ -59,7 +59,7 @@ for ii = 1:n_lc
     
     loc1 = size(combis,1) + 1;
     loc2 = loc1 + size(combis_ii,1) - 1;
-    load_combs_all(loc1:loc2) = {load_combs{ii}};
+    load_combs_all(loc1:loc2) = load_combs(ii);
     
     combis   = [combis; combis_ii];
     weights  = [weights; weights_ii];  

--- a/code/calibration/calibration_utils/standard_related/inv_design.m
+++ b/code/calibration/calibration_utils/standard_related/inv_design.m
@@ -13,6 +13,7 @@ function Prob = inv_design(free_par, fix_par, Prob, Prob_actions, Options, load_
 % -------------------------------------------------------------------------
 resistance_model    = Options.resistance_model;
 load_combination    = Options.load_combination;
+consider_VRmin      = Options.consider_VRmin;
 K_FI_repr           = Options.K_FI_repr;
 
 chi1                = fix_par(1);
@@ -69,7 +70,7 @@ psi02               = Prob.psi02.mean;
 switch lower(resistance_model)
     case 'ec2_codified_2019'
         gamma_R = free_par(1);
-        VR      = EC2_codified_2019(f_cc, Asl, b, d, theta_R, gamma_R);
+        VR      = EC2_codified_2019(f_cc, Asl, b, d, theta_R, gamma_R, consider_VRmin);
     case 'ec2_new'
         gamma_C = 1.5;
         gamma_M = free_par(1);

--- a/code/calibration/calibration_utils/standard_related/inv_design.m
+++ b/code/calibration/calibration_utils/standard_related/inv_design.m
@@ -13,6 +13,7 @@ function Prob = inv_design(free_par, fix_par, Prob, Prob_actions, Options, load_
 % -------------------------------------------------------------------------
 resistance_model    = Options.resistance_model;
 load_combination    = Options.load_combination;
+K_FI_repr           = Options.K_FI_repr;
 
 chi1                = fix_par(1);
 chi2                = fix_par(2);
@@ -110,7 +111,7 @@ end
 % Design
 % -------------------------------------------------------------------------
 % full utilization, E_d = R_d
-G_k             = fzero(@(x) VR - VE(x), 30);
+G_k             = fzero(@(x) VR - K_FI_repr * VE(x), 30);
 Q1_k            = G_k*chi1/(1-chi1);
 Q2_k            = G_k*chi2/(1-chi2);
 

--- a/code/calibration/get_input.m
+++ b/code/calibration/get_input.m
@@ -112,15 +112,15 @@ end
 switch lower(resistance_model)
     case 'ec2_codified_2019'
         if consider_VRmin
-            Prob.theta_R.mean   = 1.1369;
-            Prob.theta_R.cov    = 0.2378;
+            Prob.theta_R.mean   = 1.13688;
+            Prob.theta_R.cov    = 0.23777;
 %             Prob.theta_R.repr   = 1.0; % codified value
-            Prob.theta_R.repr   = 0.8170; % to obtain characteristics value (5%) for V_Rc
+            Prob.theta_R.repr   = 0.81707; % to obtain characteristics value (5%) for V_Rc
         else
-            Prob.theta_R.mean   = 1.1375;
-            Prob.theta_R.cov    = 0.2376;
+            Prob.theta_R.mean   = 1.13750;
+            Prob.theta_R.cov    = 0.23760;
 %             Prob.theta_R.repr   = 1.0; % codified value
-            Prob.theta_R.repr   = 0.8178; % to obtain characteristics value (5%) for V_Rc
+            Prob.theta_R.repr   = 0.81776; % to obtain characteristics value (5%) for V_Rc
         end
         
         Prob.theta_R.std    = NaN;

--- a/code/calibration/main_calibration.m
+++ b/code/calibration/main_calibration.m
@@ -51,16 +51,16 @@ Options.weights_filepath    = fullfile(data_dir, 'load_comb_prevalence_weights.x
 
 % Target reliability
 % Options.beta_target         = 4.2;
-% Options.beta_target         = 4.7;
-Options.beta_target         = 5.2;
+Options.beta_target         = 4.7;
+% Options.beta_target         = 5.2;
 
 % EN 1990, Table B3; action scaler in semi-probabilistic design
 % RC1: beta_target = 4.2; K_FI_repr = 0.9
 % RC2: beta_target = 4.7; K_FI_repr = 1.0
 % RC3: beta_target = 5.2; K_FI_repr = 1.1
 % Options.K_FI_repr           = 0.9;
-% Options.K_FI_repr           = 1.0;
-Options.K_FI_repr           = 1.1;
+Options.K_FI_repr           = 1.0;
+% Options.K_FI_repr           = 1.1;
 
 Options.verbose             = 1;
 

--- a/code/calibration/main_calibration.m
+++ b/code/calibration/main_calibration.m
@@ -50,8 +50,17 @@ data_dir                    = '../../data/';
 Options.weights_filepath    = fullfile(data_dir, 'load_comb_prevalence_weights.xlsx');
 
 % Target reliability
-% Options.beta_target         = 3.8;
-Options.beta_target         = 4.7;
+% Options.beta_target         = 4.2;
+% Options.beta_target         = 4.7;
+Options.beta_target         = 5.2;
+
+% EN 1990, Table B3; action scaler in semi-probabilistic design
+% RC1: beta_target = 4.2; K_FI_repr = 0.9
+% RC2: beta_target = 4.7; K_FI_repr = 1.0
+% RC3: beta_target = 5.2; K_FI_repr = 1.1
+% Options.K_FI_repr           = 0.9;
+% Options.K_FI_repr           = 1.0;
+Options.K_FI_repr           = 1.1;
 
 Options.verbose             = 1;
 

--- a/code/calibration/main_calibration_theta_Rk.m
+++ b/code/calibration/main_calibration_theta_Rk.m
@@ -48,6 +48,8 @@ Options.load_comb_weights   = [1, 1, 1, 1];
 data_dir                    = '../../data/';
 % Weights for design scenarios (comment or uncomment)
 Options.weights_filepath    = fullfile(data_dir, 'load_comb_prevalence_weights.xlsx');
+
+Options.K_FI_repr           = 1.0;
 % .........................................................................
 
 % Target reliability
@@ -68,8 +70,9 @@ Prob_actions                = update_Prob(Prob_actions, Options.verbose);
 tic
 [calibr_par, objfun_val, exitflag] = calibrate_theta_Rk(Prob, Prob_actions, DS, Options);
 toc
-disp('calibr_par')
-disp(calibr_par)
+disp(['calibrated theta_R_repr (P=',...
+    sprintf('%.2f', Options.P_repr_target), '): ',...
+    sprintf('%.5f', calibr_par)])
 
 %--------------------------------------------------------------------------
 % CLEAN UP


### PR DESCRIPTION
## Why

To fairly compare the optimal partial factors corresponding to different target reliability levels we should not only change the target reliability but the semi-probabilistic format as well because this is what EN1990 suggests.

## What

EN 1990:2005 Annex B is an informative annex to provides recommendations on how to adjust the semi-probabilistic format when other than RC2 reliability classes wanted to be considered. The relevant tables are included here for convenience:

![image](https://user-images.githubusercontent.com/6670894/160278369-c2b28458-6859-4b27-8286-033e587c6106.png)

![image](https://user-images.githubusercontent.com/6670894/160278416-93eca909-b753-4f10-8a2c-754e2df8de39.png)

My interpretation is that by using `K_FI` one can use the same partial factors as for RC2, which is convenient, granted that we such a simple modification is sufficient and the numbers in Table B3 are calibrated.

The limit state function for the semi-probabilistic design is modified from `VRd = VEd` to `VRd = K_FI * VEd`.

The user should ensure that the `Options.target_reliability` and `Options.K_FI_repr` values are set to reflect the desired case (`K_FI_repr` plays the role `K_FI` of Table B3).

## Testing

With the simple load combination rule:

|formulation/version| `beta_target` | `K_FI` | optimal `gamma_C`  |
| -- | -- | -- | -- |
|old (before this pull request)| 4.7 | NA | 1.3815 | 
|new  (this pull request)| 4.7 | 1.0 | 1.3815 |
|new  (this pull request)| 4.2 | 0.9 | 1.3016 |
|new  (this pull request)| 5.7 | 1.1 | 1.4860 |

If the `K_FI` approach of Annex B and `Table B3 numbers were "good" then the optimal partial factors should be the same (or close), this is clearly not the case.

## Other

- fix issues with #9 
- address most of the warnings raised by the Matlab IDE
