### PR TITLE
Improve the performance of the MC2010 resistance model

### DIFF
--- a/code/shared_utils/resistance_models/fzero_MC2010_level_II_codified_2019.m
+++ b/code/shared_utils/resistance_models/fzero_MC2010_level_II_codified_2019.m
@@ -1,6 +1,6 @@
 % MC2010 level II shear resistance formula.
 %
-% [VR, ID] = MC2010_LEVEL_II_CODIFIED_2019(fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R)
+% [VR, ID] = FZERO_MC2010_LEVEL_II_CODIFIED_2019(fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R)
 %
 % MIND THE UNITS! The formula is dimensionally inconsistent.
 % The implementation is based on `Model Code 2010. Final draft. September
@@ -26,7 +26,7 @@
 %           1: VR 
 %           2: VRmin
 
-function [VR, ID] = MC2010_level_II_codified_2019(fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R)
+function [VR, ID] = fzero_MC2010_level_II_codified_2019(fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R)
 
 % -------------------------------------------------------------------------
 % Initialize
@@ -35,13 +35,14 @@ function [VR, ID] = MC2010_level_II_codified_2019(fc, Asl, b, d, d_lower, a_to_d
     equalize_vector_lengths( ...
         fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R ...
     );
+n = length(fc);
 
 % -------------------------------------------------------------------------
 % MC2010 - level II, according to par. 7.3.3.2
 % -------------------------------------------------------------------------
-z = 0.9 .* d;
-a = a_to_d_ratio .* d;
-Es = 2.1e5;                % [N/mm2]
+z           = 0.9 .* d;
+a           = a_to_d_ratio .* d;
+Es          = 2.1e5;                % [N/mm2]
 
 % dg - maximum aggregate size [mm]
 % according to Yuguang's email of 2022-Mar-27
@@ -52,44 +53,34 @@ dg_for_kdg = dg;
 % fracture of aggregate particles."
 dg_for_kdg(fc > 70) = 0;
 
-kdg = 32 ./ (16 + dg_for_kdg);   % according to eq. (7.3-20)
+kdg         = 32 ./ (16 + dg_for_kdg);   % according to eq. (7.3-20)
 kdg(kdg < 0.75) = 0.75;
 
-% calculate design shear resistance in [kN], according to eqs. (7.3-17) and 
+% calculate design shear resistance in [kN], according to eqs. (7.3-17) and (7.3-21):
+V0          = 2.5e3;
 
-% auxiliary variables
-% V independent term in eq. (7.3-21)
-c1 = 0.4 * 1300 ./ (1000 + kdg .* z);
-
-% eps_x = V * c2; based on eq. (7.3-16) and the accompanying text
-c2 = (a ./ z + 1) ./ (2 * Es .* Asl);
-
-% right hand side of eq. (7.3-17) without kv
-c3 = theta_R .* min(sqrt(fc), 8) ./ gamma_R .* b .* z;
-
-% eq. (7.3-17) with the c coefficients: V = c1 * c3 / (1 + 1500*c3*V)
-% coeffs of a quadratic equation of the form of: a*x^2 + b*x + c
-a = 1500 * c2;
-b = 1;
-c = -c1 .* c3;
-
-VR = (-b + sqrt(b.^2 - 4*a.*c))./(2*a);
-
-% correct if eps_x limits are reached
-eps_x = VR .* c2;
-% eps_x < 0; impossible under our assumptions (c2) so it is commented out
-% bm_negative_epsx = eps_x < 0;
-% VR(bm_negative_epsx) = c1(bm_negative_epsx) .* c3(bm_negative_epsx);
-
-% eps_x > 0.003
-bm_large_epsx = eps_x > 0.003;
-% 5.5 = 1 + 1500 * 0.003
-if any(bm_large_epsx)
-    VR(bm_large_epsx) = c1(bm_large_epsx) / 5.5 .* c3(bm_large_epsx);
+VR          = nan(size(fc));
+for ii = 1:n
+    epsx  = @(V) epsx_fun(V, a(ii), z(ii), Asl(ii));
+    % eq. (7.3-21)
+    kv     = @(V) (0.4 / (1 + 1500 * epsx(V))) * (1300 / (1000 + kdg(ii) * z(ii)));
+    VR_    = fzero(@(V) (theta_R(ii) * kv(V) * (min(sqrt(fc(ii)), 8) / gamma_R(ii)) * b(ii) * z(ii)) - V, V0);
+    VR(ii) = 1.0 * VR_;
 end
-
-VR = 1e-3 .* VR;
+VR          = 1e-3 .* VR;
 
 ID = ones(size(VR));
+% ..................................
+% Utility function
+% ..................................
+
+    function e = epsx_fun(V, a, z, Asl)
+        % "longitudinal strain is calculated at the mid-depth of the
+        % effective shear depth or core layer"
+        % based on eq. (7.3-16) and the accompanying text
+        e = (V * a / z + V ) / (2 * Es * Asl);
+        e(e > 0.003) = 0.003;
+        e(e < 0) = 0;
+    end
 
 end

--- a/code/shared_utils/resistance_models/test_perf_MC2010_level_II.m
+++ b/code/shared_utils/resistance_models/test_perf_MC2010_level_II.m
@@ -1,0 +1,44 @@
+% 
+clearvars; close all; clc
+
+theta_R = 1.0;
+gamma_R = 1.0;
+
+fc = linspace(20, 100, 5000);
+% to activate the epsx > 0.003 part of the code as well
+rhos = [0.01, 0.001];
+b = 100;
+d = 300;
+d_lower = 16;
+a_to_d_ratio = 3;
+
+for ii = 1:length(rhos)
+    rho = rhos(ii);
+    Asl = b * d * rho;
+    
+    t_start = tic;
+    VR = fzero_MC2010_level_II_codified_2019( ...
+        fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
+    t_elapsed = toc(t_start);
+    
+    t_start = tic;
+    pVR = MC2010_level_II_codified_2019( ...
+        fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
+    t_elapsed_vect = toc(t_start);
+    
+    assert(all(abs(pVR - VR) < 1e-4))
+    
+    disp(['root finding & loop (fzero):  ', sprintf('%.3e', t_elapsed), ' sec'])
+    disp(['vectorized:                   ', sprintf('%.3e', t_elapsed_vect), ' sec'])
+    
+    subplot(1,2,ii)
+    plot(fc, VR, 'LineWidth', 2)
+    hold on
+    plot(fc, pVR, '--', 'LineWidth', 2)
+    xlabel('$f_\mathrm{c}$ [MPa]')
+    ylabel('$V_\mathrm{R}$ [kN]')
+    grid on
+    title(['$\rho=$', sprintf('%.3e', rho)])
+    
+    prettify(gcf)
+end

--- a/code/shared_utils/resistance_models/test_perf_MC2010_level_II.m
+++ b/code/shared_utils/resistance_models/test_perf_MC2010_level_II.m
@@ -1,10 +1,12 @@
-% 
+% Test the vectorized implementation of the MC2010 level II resistance
+% model + approximate timing
 clearvars; close all; clc
 
 theta_R = 1.0;
 gamma_R = 1.0;
 
-fc = linspace(20, 100, 5000);
+len_vecs = round(logspace(0, 4, 10));
+
 % to activate the epsx > 0.003 part of the code as well
 rhos = [0.01, 0.001];
 b = 100;
@@ -12,33 +14,61 @@ d = 300;
 d_lower = 16;
 a_to_d_ratio = 3;
 
-for ii = 1:length(rhos)
-    rho = rhos(ii);
-    Asl = b * d * rho;
-    
-    t_start = tic;
-    VR = fzero_MC2010_level_II_codified_2019( ...
-        fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
-    t_elapsed = toc(t_start);
-    
-    t_start = tic;
-    pVR = MC2010_level_II_codified_2019( ...
-        fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
-    t_elapsed_vect = toc(t_start);
-    
-    assert(all(abs(pVR - VR) < 1e-4))
-    
-    disp(['root finding & loop (fzero):  ', sprintf('%.3e', t_elapsed), ' sec'])
-    disp(['vectorized:                   ', sprintf('%.3e', t_elapsed_vect), ' sec'])
-    
-    subplot(1,2,ii)
-    plot(fc, VR, 'LineWidth', 2)
-    hold on
-    plot(fc, pVR, '--', 'LineWidth', 2)
-    xlabel('$f_\mathrm{c}$ [MPa]')
-    ylabel('$V_\mathrm{R}$ [kN]')
-    grid on
-    title(['$\rho=$', sprintf('%.3e', rho)])
-    
-    prettify(gcf)
+num_lens = length(len_vecs);
+
+t_fzero = nan(1, num_lens);
+t_vect = nan(1, num_lens);
+for ii = 1:num_lens
+    len_vec = len_vecs(ii);
+    fc = linspace(20, 100, len_vec);
+    disp('------------------------------------')
+    disp(['vector length: ', num2str(len_vec)])
+
+    for jj = 1:length(rhos)
+        rho = rhos(jj);
+        Asl = b * d * rho;
+        
+        t_start = tic;
+        VR = fzero_MC2010_level_II_codified_2019( ...
+            fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
+        t_elapsed = toc(t_start);
+        
+        t_start = tic;
+        pVR = MC2010_level_II_codified_2019( ...
+            fc, Asl, b, d, d_lower, a_to_d_ratio, theta_R, gamma_R);
+        t_elapsed_vect = toc(t_start);
+        
+        assert(all(abs(pVR - VR) < 1e-4))
+        
+        disp(['root finding & loop (fzero):  ', sprintf('%.3e', t_elapsed), ' sec'])
+        disp(['vectorized:                   ', sprintf('%.3e', t_elapsed_vect), ' sec'])
+
+        t_fzero(ii) = t_elapsed;
+        t_vect(ii) = t_elapsed_vect;
+        
+        if ii == num_lens
+            subplot(1,2,jj)
+            plot(fc, VR, 'LineWidth', 2)
+            hold on
+            plot(fc, pVR, '--', 'LineWidth', 2)
+            xlabel('$f_\mathrm{c}$ [MPa]')
+            ylabel('$V_\mathrm{R}$ [kN]')
+            grid on
+            legend('loop \& fzero', 'vect', 'Location', 'southeast')
+            title(['$\rho=$', sprintf('%.3e', rho)])
+            
+            prettify(gcf)
+        end
+    end
 end
+
+% compare runtime
+figure
+loglog(len_vecs, t_fzero, 'LineWidth', 2)
+hold on
+plot(len_vecs, t_vect, '--', 'LineWidth', 2)
+legend('loop \& fzero', 'vect')
+xlabel('Length of input vectors')
+ylabel('Runtime [s]')
+grid on
+prettify(gcf)


### PR DESCRIPTION
## Why

The current implementation is slow for a large number of design scenarios but the formula seems to be simple enough to rearrange it analytically and in turn make it faster to evaluate.

## What

- avoid explicit Matlab loop
- avoid `fzero`
- the root finding is reduced to solving a quadratic polynomial equation -> closed form solution

## Testing

- validated with the first implementation (loop and `fzero`):
  * on the level of shear resistances (`test_perf_MC2010_level_II.m`)
  * on the level of obtained `gamma_C` for a selected case

<img src="https://user-images.githubusercontent.com/6670894/162608450-59e0511e-62b4-4dd5-a7ca-250b276c8603.png" width="600" />

To give an approximate impression about the speed up:

<img src="https://user-images.githubusercontent.com/6670894/162608491-8e999955-20fd-454f-a23f-5352b0210872.png" width="600" />